### PR TITLE
Pin the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+FROM ubuntu:26.04@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
 
 ARG PHIX_VERSION=1.0.5a
 
-RUN apt update && apt install -y wget unzip
+RUN apt-get update && apt-get install --yes --no-install-recommends ca-certificates wget unzip
 
 RUN zipname="phix.${PHIX_VERSION}.zip" && \
     wget "http://phix.x10.mx/p64" && \
@@ -11,15 +11,14 @@ RUN zipname="phix.${PHIX_VERSION}.zip" && \
     chmod 777 p && \
     mv p /usr/local/bin/p && \
     unzip "${zipname}" -d /usr/local/phix && \
+    rm "${zipname}" && \
     mv /usr/local/phix/builtins /usr/local/bin/builtins && \
     cd /usr/local/bin && \
-    find "/usr/local/phix" -type f -executable -exec ln -s {} \; && \
-    echo "done?"
+    find "/usr/local/phix" -type f -executable -exec ln -s {} \;
+
+RUN apt-get purge --auto-remove --yes ca-certificates wget unzip && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN p --version
-
-# install packages required to run the tests
-#RUN apk add --no-cache jq coreutils
 
 WORKDIR /opt/test-runner
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ARG PHIX_VERSION=1.0.5a
 


### PR DESCRIPTION
Exercism's policy is to prefer pinned versions.
Using the same hash across all runners allows us to store and reuse the same image, rather than needing to store a per-runner base image. This helps cut down on storage costs.
